### PR TITLE
fix query display issue in ZnUrl-#gtUrlFor:

### DIFF
--- a/src/GToolkit-Inspector/ZnUrl.extension.st
+++ b/src/GToolkit-Inspector/ZnUrl.extension.st
@@ -154,7 +154,8 @@ ZnUrl >> gtUrlFor: aView [
 						self queryDo: [ :key :value |
 							first ifFalse: [ out nextPut: $& ].
 							first := false.
-							out nextPutAll: key; nextPut: $=; nextPutAll: value ] ] ]
+							out nextPutAll: key.
+							value ifNotNil: [ out nextPut: $=; nextPutAll: value ] ] ] ]
 				. self query }.
 			{ 'fragment'
 				. self fragment ifNil: [ '' ] ifNotNil: [ '#' , self fragment ]


### PR DESCRIPTION
Query parameters are not necessarily 'key=value', sometimes they are simply 'key'

If ZnUrl has a query with key->nil it will format simply as 'key'

The gtUrlFor: assume there will always be a value and throws an error when values are nil.

This is a fix for that case.