### PR TITLE
Update README.md - Typo in spelling of Toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # GT Inspector
-GT Inspector is the moldable inspector. It is part of [Glamorous Toolkit](https://github.com/feenkcom/gtoolkit). Please use the Glamorous Toolit distribution.
+GT Inspector is the moldable inspector. It is part of [Glamorous Toolkit](https://github.com/feenkcom/gtoolkit). Please use the Glamorous Toolkit distribution.


### PR DESCRIPTION
typo in the spelling of Toolkit.
Toolit -> Toolkit