### PR TITLE
Enh dict and url views

### DIFF
--- a/src/GToolkit-Inspector/Dictionary.extension.st
+++ b/src/GToolkit-Inspector/Dictionary.extension.st
@@ -21,6 +21,8 @@ Dictionary >> gtItemsFor: aView [
 		contextItemLabel: 'Inspect association' action: [ :anElement :aTreeNode | 
 			anElement phlow spawnObject: aTreeNode value ];
 		send: [ :assoc | assoc value  ]
+		
+	"Implementation note: association sorting uses #collatedBy: to avoid a 'Symbol DNU value: value: error'"
 ]
 
 { #category : #'*GToolkit-Inspector' }

--- a/src/GToolkit-Inspector/Dictionary.extension.st
+++ b/src/GToolkit-Inspector/Dictionary.extension.st
@@ -6,10 +6,10 @@ Dictionary >> gtItemsFor: aView [
 	^ aView columnedTree
 		title: 'Items';
 		priority: 1;
-		items: [ self associations ];
+		items: [ self associations sort: (#key collatedBy: #asString) ];
 		children: [ :each | 
 			each value isDictionary
-				ifTrue: [ each value associations ]
+				ifTrue: [ each value associations sort: (#key collatedBy: #asString) ]
 				ifFalse: [ 
 					(each value isArray and: [ each value allSatisfy: #isDictionary ])
 						ifTrue: [ each value collectWithIndex: [ :x :i | i -> x ] ]

--- a/src/GToolkit-Inspector/ZnUrl.extension.st
+++ b/src/GToolkit-Inspector/ZnUrl.extension.st
@@ -7,7 +7,7 @@ ZnUrl >> gtActionWebBrowseFor: anAction [
         BrButton new
             aptitude: BrGlamorousButtonWithIconAptitude;
             action:  [ WebBrowser openOn: self ];
-            icon: BrGlamorousIcons go asElement;
+            icon: BrGlamorousVectorIcons link;
             label: 'Open in Web Browser' translated ]
 ]
 


### PR DESCRIPTION
- ZnUrl Web Browse Action - Use intention revealing "link" icon instead of generic "go" icon
- Dictionary ItemsView: For all but the smallest dictionaries, it can be inefficient to browse an unordered items view. This PR sorts the view alphabetically by key.

Before:
![Screenshot 2024-09-02 at 2 45 17 PM](https://github.com/user-attachments/assets/7a0f4a3c-18b4-4c0a-804b-4358fad007ff)


After: 
![Screenshot 2024-09-02 at 2 46 22 PM](https://github.com/user-attachments/assets/ff4e6f30-bad9-48c8-8312-da63dc70f920)
